### PR TITLE
UX Iterations

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -1,8 +1,9 @@
 body {
   background-color: #ffbc71;
-  background-image: url(https://stake.rocketpool.net/assets/bg-new-5e43070a.webp);
+  background-image: url(images/bg.webp);
   background-size: cover;
   background-position: center center;
+  font-family: sans-serif;
   margin: 0;
   padding: 0;
 }
@@ -21,7 +22,7 @@ header {
 
 section {
   padding: 10px;
-  display: flex;
+  display: none;
   flex-direction: column;
   align-items: center;
   border: 1px solid grey;
@@ -29,6 +30,18 @@ section {
   padding: 30px;
   border-radius: 0.375rem;
   background-color: rgba(20,20,20,.1);
+}
+
+.status {
+  color: white;
+  margin: 30px;
+  padding: 30px;
+  border-radius: 0.375rem;
+  background-color: rgba(255, 35, 35, 0.556);
+}
+
+section.section-active {
+  display: flex;
 }
 
 label.address > input {
@@ -47,9 +60,11 @@ input[type=text]:read-only {
   border-style: solid;
 }
 
-input[type=button] {
+input[type=button], button {
+  position: relative;
   border: none;
   background: #0f172a;
+  opacity: .6;
   color: white;
   border-radius: .375rem;
   padding: 10px;
@@ -57,6 +72,10 @@ input[type=button] {
   cursor: pointer;
   font-size: 1.25rem;
   line-height: 1.75rem;
+}
+
+input[type=button]:hover, button {
+  opacity: 1;
 }
 
 span.ens {
@@ -117,4 +136,45 @@ span.rocketSplit > span {
 }
 .hidden, div.hidden {
   display: none;
+}
+
+.button--loading .button--text {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.button--loading::after {
+  content: "";
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: auto;
+  border: 4px solid transparent;
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: rotation 1s ease infinite;
+}
+
+.loader {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #FFF;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+      transform: rotate(0deg);
+  }
+  100% {
+      transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
In this PR we split the UX into more distinct modes. Enabling users to connect their wallet and then find their nodes before being presented with the creation / manage interface. 

Also added some improved error checking and a new design around the connect wallet and find node buttons. 

Lastly, took out the inline styling we had previously. 

A demo of this has been updated at the url below. We did update this demo to connect to the Goerli test factory: 

https://rocketsplit.surge.sh/