### PR TITLE
Updated claims component.

### DIFF
--- a/react-ui/package-lock.json
+++ b/react-ui/package-lock.json
@@ -19,7 +19,8 @@
         "react-toastify": "^9.1.3",
         "viem": "^1.6.0",
         "wagmi": "^1.3.10",
-        "web-vitals": "^2.1.0"
+        "web-vitals": "^2.1.0",
+        "zstandard-wasm": "^1.5.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
@@ -19670,6 +19671,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zstandard-wasm": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/zstandard-wasm/-/zstandard-wasm-1.5.0.tgz",
+      "integrity": "sha512-YwbuHJVxl6Ux4lS+Xrt5bF2nL776j6i4oZAdD8AdI6l+MDRbtGm2Q9J39yVbN/Qr9wWTZR4Lms9YYeH+NrvfYA=="
     },
     "node_modules/zustand": {
       "version": "4.4.1",

--- a/react-ui/src/App.js
+++ b/react-ui/src/App.js
@@ -23,6 +23,7 @@ import MarriageCreator from './components/MarriageCreator';
 
 import { ToastContainer, toast } from 'react-toastify';
 import MarriageList from './components/MarriageList';
+import ClaimIntervals from './components/ClaimIntervals';
 
 
 
@@ -128,6 +129,9 @@ function App() {
                           setPendingWithdrawalAddress={setPendingWithdrawalAddress}
                           setWithdrawalAddress={setWithdrawalAddress}
                           isRocketSplit={isRocketSplit}/>
+                       }
+                       {withdrawalAddress &&
+                        <ClaimIntervals nodeAddress={nodeAddress} setPendingClaims={setPendingClaims} setNodeMinipools={setNodeMinipools}/>
                        }
                       {!splitAddress &&
                         <MarriageCreator withdrawalAddress={withdrawalAddress} 

--- a/react-ui/src/components/ClaimIntervals.js
+++ b/react-ui/src/components/ClaimIntervals.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { keccak256 } from "viem";
 import { useContractRead, useContractReads, usePublicClient, useNetwork } from "wagmi";
 import zstd from 'zstandard-wasm';
 
@@ -24,22 +25,45 @@ const ClaimIntervals = ({ nodeAddress, setPendingClaims, setNodeMinipools }) => 
         abi: [{"inputs":[{"internalType":"bytes32","name":"_key","type":"bytes32"}],"name":"getAddress","outputs":[{"internalType":"address","name":"r","type":"address"}],"stateMutability":"view","type":"function"}]
     };
 
-    const getAddress = (name, setAddress) => {
-      useContractRead({
-          ...storageContractConfig,
-          functionName: "getAddress",
-          args: [keccak256(`contract.address${name}`)],
-          onLoading: () => console.log("Loading..."),
-          onError: (error) => console.log("Error: " + error),
-          onSuccess: (result) => {
-              setAddress(result);
-          }
-      })
-    }
+    //--------------------------------------------------------------------------------
+    // Get the various addresses we need.
+    //--------------------------------------------------------------------------------
+    useContractRead({
+        ...storageContractConfig,
+        functionName: "getAddress",
+        args: [keccak256(`contract.addressrocketRewardsPool`)],
+        onLoading: () => console.log("Loading..."),
+        onError: (error) => console.log("Error: " + error),
+        onSuccess: (result) => {
+            console.log(`rocketRewardsPoolAddress ${result}`)
+            setRocketRewardsPoolAddress(result);
+        }
+    })
 
-    getAddress('rocketRewardsPool', setRocketRewardsPoolAddress)
-    getAddress('rocketMinipoolManager', setRocketMinipoolManagerAddress)
-    getAddress('rocketMerkleDistributor', setRocketMerkleDistributorAddress)
+    useContractRead({
+        ...storageContractConfig,
+        functionName: "getAddress",
+        args: [keccak256(`contract.addressrocketMinipoolManager`)],
+        onLoading: () => console.log("Loading..."),
+        onError: (error) => console.log("Error: " + error),
+        onSuccess: (result) => {
+            console.log(`rocketMinipoolManagerAddress ${result}`)
+            setRocketMinipoolManagerAddress(result);
+        }
+    })
+
+    useContractRead({
+        ...storageContractConfig,
+        functionName: "getAddress",
+        args: [keccak256(`contract.addressrocketMerkleDistributor`)],
+        onLoading: () => console.log("Loading..."),
+        onError: (error) => console.log("Error: " + error),
+        onSuccess: (result) => {
+            console.log(`rocketMerkleDistributorAddress ${result}`)
+            setRocketMerkleDistributorAddress(result);
+        }
+    })
+    //--------------------------------------------------------------------------------
 
     useContractRead({
         address: rocketRewardsPoolAddress,
@@ -130,7 +154,7 @@ const ClaimIntervals = ({ nodeAddress, setPendingClaims, setNodeMinipools }) => 
         contracts: Array.from(Array(currentIntervalIndex).keys()).map(i =>
             ({address: rocketMerkleDistributorAddress,
               abi: merkleDistributorAbi,
-              functionName: "isClaimed"
+              functionName: "isClaimed",
               args: [i, nodeAddress]})),
         onSuccess: (data) => {
             const result = data.flatMap((claimed, index) => claimed ? [] : [index])
@@ -140,6 +164,17 @@ const ClaimIntervals = ({ nodeAddress, setPendingClaims, setNodeMinipools }) => 
         }
     })
 
+    return (
+        <div className="rocket-panel">
+            <h2>Claim Intervals</h2>
+            <p>Claim intervals for {nodeAddress}:</p>
+            <ul>
+                {unclaimedIntervals?.map(i => <li key={i}>{i}</li>)}
+            </ul>
+            <p># Minipools for {nodeAddress}:</p>
+            <h2>{minipoolCount}</h2>
+        </div>
+    )
 
 }
 


### PR DESCRIPTION
Made a few changes to grab the required rocketpool contract addresses. This PR also illustrates how to output the results of the contract calls for testing. There is still work here but hopefully this gets us closer to testing the results from the various contract calls. 

To test you should be able to perform a `npm install` and `npm run start` from within the react-ui directory. 

You can use the Holesky node at the address below:
0x65Ab32B9D795718f5106A8DAaa51cf79c6931b4d