### PR TITLE
Refactor how we are retrieving reward trees.

### DIFF
--- a/react-ui/src/components/ClaimIntervals.js
+++ b/react-ui/src/components/ClaimIntervals.js
@@ -165,7 +165,7 @@ const ClaimIntervals = ({ nodeAddress, withdrawalAddress }) => {
           while (true) { // Loop indefinitely until break
               let url = new URL(`/rocket-pool/rewards-trees/main/${chain.name.toLowerCase()}/rp-rewards-${chain.name.toLowerCase()}-${rewardIndex}.json`, 'https://raw.githubusercontent.com/');
 
-              if (chain.name.toLowerCase() == "foundry") {
+              if (chain.name.toLowerCase() === "foundry") {
                   url = new URL(`/rocket-pool/rewards-trees/main/mainnet/rp-rewards-mainnet-${rewardIndex}.json`, 'https://raw.githubusercontent.com/');
               }
 


### PR DESCRIPTION
Previously we were doing a bunch of work to use IPFS. This included querying the chain logs to get the cid. This was proven not to work very well.

This patch simplifies the process by relying on the Rocketpool Github mirror located here: https://github.com/rocket-pool/rewards-trees/tree/main